### PR TITLE
Support for creating a recurring payment profile using a Billing Agreement instead of a CreditCard

### DIFF
--- a/payflowpro/classes.py
+++ b/payflowpro/classes.py
@@ -162,6 +162,10 @@ class CreditCardPresent(PayflowProObject):
 
 ##### Express Checkout request classes #####
 
+
+class BillingType(PayflowProObject):
+    billingtype=Field(required=True)
+
 class SetPaypal(PayflowProObject):
     returnurl = Field(required=True)
     cancelurl = Field(required=True)

--- a/payflowpro/classes.py
+++ b/payflowpro/classes.py
@@ -186,6 +186,9 @@ class Amount(PayflowProObject):
     dutyamt = Field()
     freightamt = Field()
     taxamt = Field()
+
+    def _get_data(self):
+        return dict([(field, obj.value) for field, obj in self.fields.items() ])
     
 class Tracking(PayflowProObject):
     comment1 = Field()

--- a/payflowpro/classes.py
+++ b/payflowpro/classes.py
@@ -188,7 +188,8 @@ class Amount(PayflowProObject):
     taxamt = Field()
 
     def _get_data(self):
-        return dict([(field, obj.value) for field, obj in self.fields.items() ])
+        return dict([(field, obj.value) for field, obj in self.fields.items()])
+    data = property(_get_data)
     
 class Tracking(PayflowProObject):
     comment1 = Field()

--- a/payflowpro/classes.py
+++ b/payflowpro/classes.py
@@ -267,7 +267,12 @@ class Profile(PayflowProObject):
     aggregateoptionalamt = Field()
     numfailpayments = Field()
     retrynumdays = Field()
+    baid = Field()
     
+    def _get_data(self):
+        return dict([(field, obj.value) for field, obj in self.fields.items() if obj.value ==0 or obj.value])
+    data = property(_get_data)
+   
 class Response(PayflowProObject):
     result = Field(required=True)
     respmsg = Field()

--- a/payflowpro/client.py
+++ b/payflowpro/client.py
@@ -295,7 +295,7 @@ class PayflowProClient(object):
         return self._do_request(request_id, params)
 
     def reference_transaction_baid(self, transaction_type, baid, amount, request_id=None, extras=[]):
-        params = dict(trxtype = transaction_type, baid = baid)
+        params = dict(trxtype = transaction_type, baid = baid,tender='P')
         for item in [amount] + extras:
             params.update(item.data)
         return self._do_request(request_id, params)

--- a/payflowpro/client.py
+++ b/payflowpro/client.py
@@ -294,6 +294,12 @@ class PayflowProClient(object):
             params.update(item.data)
         return self._do_request(request_id, params)
 
+    def reference_transaction_baid(self, transaction_type, baid, amount, request_id=None, extras=[]):
+        params = dict(trxtype = transaction_type, baid = baid)
+        for item in [amount] + extras:
+            params.update(item.data)
+        return self._do_request(request_id, params)
+
     ##### Implementations of paypal express checkout #####
 
     def set_checkout(self, setpaypal, amount, extras=[]):        

--- a/payflowpro/client.py
+++ b/payflowpro/client.py
@@ -197,7 +197,6 @@ class PayflowProClient(object):
         while (results is None and try_count < self.MAX_RETRY_COUNT):
             try:
                 try_count += 1
-                print self.url_base 
                 request = Request(
                     url = self.url_base, 
                     data = parmlist.encode('utf-8'), 

--- a/payflowpro/client.py
+++ b/payflowpro/client.py
@@ -197,7 +197,7 @@ class PayflowProClient(object):
         while (results is None and try_count < self.MAX_RETRY_COUNT):
             try:
                 try_count += 1
-                
+                print self.url_base 
                 request = Request(
                     url = self.url_base, 
                     data = parmlist.encode('utf-8'), 
@@ -330,6 +330,12 @@ class PayflowProClient(object):
     def profile_add(self, profile, credit_card, amount, request_id=None, extras=[]):
         params = dict(trxtype = 'R', action = 'A')
         for item in [profile, credit_card, amount] + extras:
+            params.update(item.data)
+        return self._do_request(request_id, params)
+
+    def profile_baid_add(self, profile, amount, request_id=None, extras=[]):
+        params = dict(trxtype = 'R', action = 'A', tender = "P")
+        for item in [profile, amount] + extras:
             params.update(item.data)
         return self._do_request(request_id, params)
 

--- a/payflowpro/client.py
+++ b/payflowpro/client.py
@@ -295,7 +295,8 @@ class PayflowProClient(object):
         return self._do_request(request_id, params)
 
     def reference_transaction_baid(self, transaction_type, baid, amount, request_id=None, extras=[]):
-        params = dict(trxtype = transaction_type, baid = baid,tender='P')
+        params = dict(trxtype = transaction_type, baid = baid,tender='P',
+                      action='D')
         for item in [amount] + extras:
             params.update(item.data)
         return self._do_request(request_id, params)

--- a/payflowpro/client.py
+++ b/payflowpro/client.py
@@ -301,6 +301,12 @@ class PayflowProClient(object):
         for item in [setpaypal, amount] + extras:
             params.update(item.data)
         return self._do_request(None, params)
+        
+   def baid_set_checkout(self, setpaypal, amount, extras=[]):
+      params = dict(trxtype = "A", action = "S")
+      for item in [setpaypal, amount] + extras:
+         params.update(item.data)
+      return self._do_request(None, params)
 
     def get_checkout(self, getpaypal, extras=[]):
         params = dict(trxtype = "S", action = "G")

--- a/payflowpro/client.py
+++ b/payflowpro/client.py
@@ -302,16 +302,16 @@ class PayflowProClient(object):
             params.update(item.data)
         return self._do_request(None, params)
         
-   def baid_set_checkout(self, setpaypal, amount, extras=[]):
-      params = dict(trxtype = "A", action = "S")
-      for item in [setpaypal, amount] + extras:
-         params.update(item.data)
-      return self._do_request(None, params)
+    def baid_set_checkout(self, setpaypal, amount, extras=[]):
+        params = dict(trxtype = "A", action = "S")
+        for item in [setpaypal, amount] + extras:
+           params.update(item.data)
+        return self._do_request(None, params)
       
-   def get_baid(self, token):
-      params = dict(trxtype = "A", action = "X", tender = "P",
-                     token = token)
-      return self._do_request(None, params)
+    def get_baid(self, token):
+        params = dict(trxtype = "A", action = "X", tender = "P",
+                       token = token)
+        return self._do_request(None, params)
 
     def get_checkout(self, getpaypal, extras=[]):
         params = dict(trxtype = "S", action = "G")


### PR DESCRIPTION
I have added some functionality to create recurring billing profiles using the `baid` paramater as described [here](https://developer.paypal.com/docs/classic/payflow/recurring-billing/#using-the-add-action) under the code example **Adding a New Profile for a PayPal Account**. To obtain the baid I use the workflow described in [this](https://www.paypalobjects.com/webstatic/en_US/developer/docs/pdf/pfp_expresscheckout_pp.pdf) document under the section entitled "Obtaining the BAID Without Express Checkout Purchase" 

Here is some sample code of these functions in action
```
# creating a token to obtain user authorization via Paypal
pclient = PayflowProClient(**kwargs)
zeroamt = Amount(amt=0.00, currency="USD")
btype = BillingType(billingtype='MerchantInitiatedBilling')
extras = [btype]
r=pclient.baid_set_checkout(setpaypal, zeroamt,extras=extras)
token = r[0][1].data['token']
```       
```
# use the authorized token to retrieve a baid
pclient = PayflowProClient(**kwargs)
baid_response = pclient.get_baid(token)
```

```
# create a recurring billing profile using the baid
args =  { "profilename": profilename, "start": start.strftime("%m%d%Y"), 
              "term": 0,"payperiod": 'MONT', 'baid': baid }
amount = Amount(amt=amt,currency="USD")
p = Profile(**args)
resp = pclient.profile_baid_add(p, amount)
```
